### PR TITLE
Tailwind config: add configuration links, remove darkMode setting

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,10 @@
+/* 
+  Explore configuration options docs https://tailwindcss.com/docs/configuration#configuration-options
+  Or check the default configuration https://unpkg.com/browse/tailwindcss@latest/stubs/defaultConfig.stub.js
+*/
+
 module.exports = {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
-  darkMode: 'media', // class
   theme: {
     extend: {}
   },


### PR DESCRIPTION
Add links to configuration option docs, to the default config. Remove darkMode setting