### PR TITLE
Resolved default import

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,6 @@
 import Avatar from 'components/Avatar'
 
-function App() {
+export function App() {
   return (
     <div className="bg-white">
       <div className="py-16 px-4 mx-auto max-w-screen-xl sm:py-24 sm:px-6 lg:px-8">
@@ -24,4 +24,3 @@ function App() {
   )
 }
 
-export default App

--- a/src/components/test.tsx
+++ b/src/components/test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 
-import App from './App'
+import { App } from './App'
 
 describe('<App />', () => {
   it('should render the App', () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client'
 import 'tailwindcss/tailwind.css'
-import App from 'components/App'
+import { App } from 'components/App'
 
 const container = document.getElementById('root') as HTMLDivElement
 const root = createRoot(container)


### PR DESCRIPTION
**Problem:** 
Remove default of export in app.tsx for follow the pattern of importation, and import named import { App } from
**Explaining:**
When exporting by default can't change the name's component in importation, then, if change the name in component should be changed in importation too, however, if export without default, you can change the name of importation component facilitating a refactoring of code.