### PR TITLE
Fix vulnerability in happy-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-tailwindcss": "^3.17.5",
-    "happy-dom": "^12.10.3",
+    "happy-dom": "^15.11.6",
     "postcss": "^8.4.49",
     "prettier": "3.1.1",
     "tailwindcss": "^3.4.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^3.17.5
         version: 3.17.5(tailwindcss@3.4.15)
       happy-dom:
-        specifier: ^12.10.3
-        version: 12.10.3
+        specifier: ^15.11.6
+        version: 15.11.6
       postcss:
         specifier: ^8.4.49
         version: 8.4.49
@@ -86,7 +86,7 @@ importers:
         version: 4.3.2(typescript@5.6.3)(vite@5.4.11(@types/node@20.17.6))
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.17.6)(@vitest/ui@1.6.0)(happy-dom@12.10.3)
+        version: 1.6.0(@types/node@20.17.6)(@vitest/ui@1.6.0)(happy-dom@15.11.6)
 
 packages:
 
@@ -1146,8 +1146,9 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  happy-dom@12.10.3:
-    resolution: {integrity: sha512-JzUXOh0wdNGY54oKng5hliuBkq/+aT1V3YpTM+lrN/GoLQTANZsMaIvmHiHe612rauHvPJnDZkZ+5GZR++1Abg==}
+  happy-dom@15.11.6:
+    resolution: {integrity: sha512-elX7iUTu+5+3b2+NGQc0L3eWyq9jKhuJJ4GpOMxxT/c2pg9O3L5H3ty2VECX0XXZgRmmRqXyOK8brA2hDI6LsQ==}
+    engines: {node: '>=18.0.0'}
 
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
@@ -1178,10 +1179,6 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
-
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1756,9 +1753,6 @@ packages:
     resolution: {integrity: sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==}
     engines: {node: '>= 0.4'}
 
-  safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
@@ -2067,10 +2061,6 @@ packages:
 
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
-    engines: {node: '>=12'}
-
-  whatwg-encoding@2.0.0:
-    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
 
   whatwg-mimetype@3.0.0:
@@ -2587,7 +2577,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      vitest: 1.6.0(@types/node@20.17.6)(@vitest/ui@1.6.0)(happy-dom@12.10.3)
+      vitest: 1.6.0(@types/node@20.17.6)(@vitest/ui@1.6.0)(happy-dom@15.11.6)
 
   '@vitest/utils@1.6.0':
     dependencies:
@@ -3313,13 +3303,10 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  happy-dom@12.10.3:
+  happy-dom@15.11.6:
     dependencies:
-      css.escape: 1.5.1
       entities: 4.5.0
-      iconv-lite: 0.6.3
       webidl-conversions: 7.0.0
-      whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
 
   has-bigints@1.0.2: {}
@@ -3343,10 +3330,6 @@ snapshots:
       function-bind: 1.1.2
 
   human-signals@5.0.0: {}
-
-  iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -3907,8 +3890,6 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.1.4
 
-  safer-buffer@2.1.2: {}
-
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -4224,7 +4205,7 @@ snapshots:
       '@types/node': 20.17.6
       fsevents: 2.3.3
 
-  vitest@1.6.0(@types/node@20.17.6)(@vitest/ui@1.6.0)(happy-dom@12.10.3):
+  vitest@1.6.0(@types/node@20.17.6)(@vitest/ui@1.6.0)(happy-dom@15.11.6):
     dependencies:
       '@vitest/expect': 1.6.0
       '@vitest/runner': 1.6.0
@@ -4249,7 +4230,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.17.6
       '@vitest/ui': 1.6.0(vitest@1.6.0)
-      happy-dom: 12.10.3
+      happy-dom: 15.11.6
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -4261,10 +4242,6 @@ snapshots:
       - terser
 
   webidl-conversions@7.0.0: {}
-
-  whatwg-encoding@2.0.0:
-    dependencies:
-      iconv-lite: 0.6.3
 
   whatwg-mimetype@3.0.0: {}
 


### PR DESCRIPTION
happy-dom allows for server side code to be executed by a <script> tag https://github.com/advisories/GHSA-96g7-g7g9-jxw8

Thank you for creating and maintaining this template; it has saved me a lot of time.

Running

```bash
pnpm dlx degit joaopaulomoraes/reactjs-vite-tailwindcss-boilerplate my-app
cd my-app
pnpm install
pnpm audit
```

displays

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ critical            │ happy-dom allows for server side code to be executed   │
│                     │ by a <script> tag                                      │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ happy-dom                                              │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <15.10.2                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=15.10.2                                              │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ . > @vitest/ui@1.6.0 > vitest@1.6.0 >                  │
│                     │ happy-dom@12.10.3                                      │
│                     │                                                        │
│                     │ . > happy-dom@12.10.3                                  │
│                     │                                                        │
│                     │ . > vitest@1.6.0 > happy-dom@12.10.3                   │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-96g7-g7g9-jxw8      │
└─────────────────────┴────────────────────────────────────────────────────────┘
```

I'm not sure if this update breaks anything. Your tests still pass though.